### PR TITLE
Install Airbridge SDK and Migrate from Firebase Dynamic Links

### DIFF
--- a/Jotify/AppDelegate.swift
+++ b/Jotify/AppDelegate.swift
@@ -8,6 +8,7 @@
 import Firebase
 import CoreData
 import AuthenticationServices
+import Airbridge
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -15,6 +16,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         FirebaseApp.configure()
+        
+        let option = AirbridgeOptionBuilder(name: "jotify", token: "5f1dac3087cf4bf0a027f3d60dd37382")
+            .setLogLevel(.debug)
+            .setSDKSignature(
+                id: "YOUR_SDK_SIGNATURE_SECRET_ID", 
+                secret: "YOUR_SDK_SIGNATURE_SECRET"
+            )
+            .setTrackAirbridgeDeeplinkOnlyEnabled(true)
+            .build()
+        
+        Airbridge.initializeSDK(option: option)
         
         //check to see if Apple credential revoked since last launch
         didAppleIDStateRevokeWhileTerminated()

--- a/Jotify/Info.plist
+++ b/Jotify/Info.plist
@@ -19,14 +19,12 @@
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-			<key>CFBundleURLName</key>
-			<string>Bundle ID</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>com.austinleath.Jotify</string>
+				<string>jotify</string>
 			</array>
+			<key>CFBundleURLName</key>
+			<string>com.austinleath.Jotify</string>
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
@@ -79,6 +77,11 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:jotify.airbridge.io</string>
+		<string>applinks:jotify.abr.ge</string>
 	</array>
 </dict>
 </plist>

--- a/Jotify/Jotify.entitlements
+++ b/Jotify/Jotify.entitlements
@@ -10,7 +10,8 @@
 	</array>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:jotify.page.link</string>
+		<string>applinks:jotify.airbridge.io</string>
+		<string>applinks:jotify.abr.ge</string>
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>

--- a/Jotify/Model/Firebase/ReferralManager.swift
+++ b/Jotify/Model/Firebase/ReferralManager.swift
@@ -6,37 +6,19 @@
 //
 
 import FirebaseAuth
-import FirebaseDynamicLinks
 import FirebaseFirestore
+import Airbridge
 
 class ReferralManager {
-    
-    //should be created when a user's account is created
     func createReferralLink() {
         let uid = AuthManager().uid
-        let link = URL(string: "https://jotifyapp.com/?invitedby=\(uid)")
-        let referralLink = DynamicLinkComponents(link: link!, domainURIPrefix: "https://jotify.page.link")
+        let referralLink = "jotify://referral?invitedby=\(uid)"
         
-        referralLink?.iOSParameters = DynamicLinkIOSParameters(bundleID: "com.austinleath.Jotify")
-        referralLink?.iOSParameters?.minimumAppVersion = "2.0.0"
-        referralLink?.iOSParameters?.appStoreID = "1469983730"
+        User.settings?.referralLink = referralLink
         
-        referralLink?.androidParameters = DynamicLinkAndroidParameters(packageName: "com.austinleath.Jotify")
-        referralLink?.androidParameters?.minimumVersion = 1
-                
-        referralLink?.shorten { (shortURL, warnings, error) in
-            if let error = error {
-                print(error.localizedDescription)
-                return
-            }
-            
-            User.settings?.referralLink = shortURL?.absoluteString ?? ""
-            
-            DataManager.updateUserSettings(setting: "referralLink", value: shortURL?.absoluteString ?? "") { success in
-                if !success! {
-                    print("Error creating and uploading referralLink to firestore")
-                }
-                
+        DataManager.updateUserSettings(setting: "referralLink", value: referralLink) { success in
+            if !success! {
+                print("Error creating and uploading referralLink to firestore")
             }
         }
     }
@@ -44,7 +26,6 @@ class ReferralManager {
     func grantReferralCredit(referrerId: String) {
         print("Adding referral credits")
         
-        //update referral count for current user
         DataManager.updateUserSettings(setting: "referrals", value: (User.settings?.referrals ?? 0) + 1) { success in
             if !success! {
                 print("Error granting referral credit")
@@ -53,27 +34,22 @@ class ReferralManager {
         
         var referrerValue: Int = 0
         
-        //get the value of the other user's setting
         let db = Firestore.firestore()
         let docRef = db.collection("users").document(referrerId)
         docRef.getDocument { (document, error) in
             if let document = document, document.exists {
-                let dataDescription = document.data().map(String.init(describing:)) ?? "nil"
                 referrerValue = document.get("referrals") as? Int ?? 0
-                print("Document data: \(dataDescription)")
+                
+                db.collection("users").document(referrerId).updateData([
+                    "referrals": referrerValue + 1,
+                ]) { error in
+                    if let error = error {
+                        print("Error adding document: \(error)")
+                    }
+                }
             } else {
                 print("Document does not exist")
             }
         }
-        
-        //set the value of the other users' setting
-        db.collection("users").document(referrerId).updateData([
-            "referrals": referrerValue + 1,
-        ]) { error in
-            if let error = error {
-                print("Error adding document: \(error)")
-            }
-        }
     }
-    
 }

--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,7 @@ target 'Jotify' do
   pod 'Firebase/Auth'
   pod 'Firebase/Firestore'
   pod 'FirebaseFirestoreSwift'
-  pod 'Firebase/DynamicLinks'
+  pod 'airbridge-ios-sdk', '4.1.0'
   
   pod 'Blueprints'
   pod 'Pageboy', '~> 3.6'


### PR DESCRIPTION
# Airbridge SDK Integration

This PR integrates Airbridge SDK to replace Firebase Dynamic Links for deep linking functionality.

## Changes

### Added
- Airbridge SDK dependency (v4.1.0)
- Airbridge initialization in AppDelegate
- Deep link handling in SceneDelegate
- Associated domains for Airbridge deep linking

### Removed
- Firebase Dynamic Links dependency
- Firebase Dynamic Links related code

### Modified
- Updated deep link handling logic in ReferralManager
- Updated URL schemes and associated domains in Info.plist
- Updated entitlements for Airbridge domains

## Implementation Details

- SDK initialization with app token: `5f1dac3087cf4bf0a027f3d60dd37382`
- Deep link format changed from `https://jotify.page.link/...` to `jotify://<path>?<parameters>`
- Added support for both URL schemes and Universal Links

## Testing Required

- [ ] Deep link handling when app is not installed
- [ ] Deep link handling when app is in background
- [ ] Deep link handling when app is in foreground
- [ ] Deep link handling on fresh install
- [ ] Referral system functionality
- [ ] Widget deep links
- [ ] Settings deep links
- [ ] Note editing deep links

## Notes

- Marketing team needs to update existing deep links to new format
- Backend team needs to update APIs to generate Airbridge-compatible links
- Please verify SDK signature credentials before merging

## Documentation

Refer to [Airbridge iOS SDK Documentation](https://developers.airbridge.io/docs/ios-sdk) for implementation details.